### PR TITLE
DNS fixes (alias support and rh/ubuntu fixes) + Role by state configuration [20/26]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-swift.json
+++ b/chef/data_bags/crowbar/bc-template-swift.json
@@ -31,6 +31,12 @@
   "deployment": {
     "swift": {
       "crowbar-revision": 0,
+      "element_states": {
+        "swift-storage": [ "readying", "ready", "applying" ],
+        "swift-proxy": [ "readying", "ready", "applying" ],
+        "swift-proxy-acct": [ "readying", "ready", "applying" ],
+        "swift-ring-compute": [ "readying", "ready", "applying" ]
+      },
       "elements": {},
       "element_order": [
         [ "swift-storage" ],  

--- a/chef/data_bags/crowbar/bc-template-swift.schema
+++ b/chef/data_bags/crowbar/bc-template-swift.schema
@@ -49,6 +49,16 @@
             "crowbar-revision": { "type": "int", "required": true },
             "crowbar-committing": { "type": "bool" },
             "crowbar-queued": { "type": "bool" },
+            "element_states": {
+              "type": "map",
+              "mapping": {
+                = : {
+                  "type": "seq",
+                  "required": true,
+                  "sequence": [ { "type": "str" } ]
+                }
+              }
+            },
             "elements": {
               "type": "map",
               "required": true,


### PR DESCRIPTION
This allows for the DNS barclamp to work correctly in ubuntu and redhat.

Update the barclamps to have element_states for mapping their roles to states for when to execute.

 chef/data_bags/crowbar/bc-template-swift.json   |    6 ++++++
 chef/data_bags/crowbar/bc-template-swift.schema |   10 ++++++++++
 2 files changed, 16 insertions(+), 0 deletions(-)
