### PR TITLE
Misc bug fixes - glance & swift [2/3]

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -141,7 +141,7 @@ execute "create auth cert" do
   group node[:swift][:group]
   user node[:swift][:user]
   command <<-EOH
-  /usr/bin/openssl req -new -x509 -nodes -out cert.crt -keyout cert.key -batch &>/dev/null 0</dev/null
+  /usr/bin/openssl req -new -x509 -days 365 -nodes -out cert.crt -keyout cert.key -batch &>/dev/null 0</dev/null
   EOH
   not_if  {::File.exist?("/etc/swift/cert.crt") } 
 end

--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -43,7 +43,6 @@ class SwiftService < ServiceObject
 
 
     base["attributes"]["swift"]["keystone_instance"] = ""
-    base["attributes"]["swift"]["auth_method"] = "swauth"
     begin
       keystoneService = KeystoneService.new(@logger)
       keystones = keystoneService.list_active[1]


### PR DESCRIPTION
swift:
- don't try to use swauth if no keystone present. no longer supporting swauth
- make the proxy cert last for a bit (default expiration was +1 month. now +1 year)
  glance:
- make API and Registry listne to all addresses by default, so CLI tools work
  
  chef/cookbooks/swift/recipes/proxy.rb         |    2 +-
  crowbar_framework/app/models/swift_service.rb |    1 -
  2 files changed, 1 insertions(+), 2 deletions(-)
