### PR TITLE
fix issues with parsing crowbar.yml files on Ruby 1.9 [1/3]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -35,7 +35,7 @@ crowbar:
   chef_order: 80
 
 debs:
-  ubuntu-12.04
+  ubuntu-12.04:
     repos:
       - deb http://ubuntu-cloud.archive.canonical.com/ubuntu precise-updates/folsom main
   pkgs:


### PR DESCRIPTION
Some of the crowbar.yml files had illegal YAML syntax.  This bundle
fixes that, and also facilitates easier debugging of similar problems
in the future.

 crowbar.yml | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 9d9e0e065e56866b3d17ffa42bb595796a133c2a

Crowbar-Release: development
