### PR TITLE
Get Pebbles to be able to deploy Nova and spin up vms. [1/6]

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -245,7 +245,6 @@ elsif node[:swift][:frontend]=='apache'
   service "swift-proxy" do
     supports :status => true, :restart => true
     action [ :disable, :stop ]
-    ignore_failure true
   end
 
 

--- a/chef/cookbooks/swift/recipes/storage.rb
+++ b/chef/cookbooks/swift/recipes/storage.rb
@@ -65,7 +65,6 @@ if (!compute_nodes.nil? and compute_nodes.length > 0 )
     execute "pull #{ring} ring" do
       command "rsync #{node[:swift][:user]}@#{compute_node_addr}::ring/#{ring}.ring.gz ."
       cwd "/etc/swift"
-      ignore_failure true
     end
   }
     


### PR DESCRIPTION
These pull request updates allow Nova and all its prerequisites to
deploy using their default proposals, and test that Nova is able to
spin up a VM.

We still need to have proper smoketests for Quantum and Cinder, and
the Nova smoketests need to include testing attaching and detaching
networks and volumes to vms.

 chef/cookbooks/swift/recipes/proxy.rb   |    1 -
 chef/cookbooks/swift/recipes/storage.rb |    1 -
 2 files changed, 2 deletions(-)

Crowbar-Pull-ID: a0c8ce902ba2ff2b08a2b4fcf2938992f2e17f34

Crowbar-Release: pebbles
