### PR TITLE
Turn down default logging verbosity for glance, ipmi, swift, and keystone. [1/4]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-swift.json
+++ b/chef/data_bags/crowbar/bc-template-swift.json
@@ -35,7 +35,7 @@
           "gitrepo": "http://github.com/fujita/swift3",
           "git_refspec": "195e6c76ff46a8f00621a56d4e13b500becc2c9a",
           "use_gitrepo": true,
-          "use_gitbarclamp": true, 
+          "use_gitbarclamp": true,
           "enabled": false
         },
         "ratelimit": {
@@ -91,8 +91,8 @@
       "reseller_prefix" : "AUTH_",
       "user": "swift",
       "group": "swift",
-      "debug": true,
-      "use_slog" : false, 
+      "debug": false,
+      "use_slog" : false,
       "slog_account": "system_stats",
       "slog_user": "swift_sys",
       "slog_passwd": "swift_pwd",
@@ -138,4 +138,3 @@
     }
   }
 }
-


### PR DESCRIPTION
We were being too verbose in our logging by default.  This pull
request turns down the volume so we don't drown in logfiles quite so fast.

 chef/data_bags/crowbar/bc-template-swift.json |    7 +++----
 1 file changed, 3 insertions(+), 4 deletions(-)

Crowbar-Pull-ID: 898b27a701f199b0536ae0303358a67f6f08c00f

Crowbar-Release: pebbles
