### PR TITLE
first remove nginx default config [1/1]

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -253,6 +253,12 @@ elsif node[:swift][:frontend]=='apache'
       action :install
     end
   end
+
+
+  link "/etc/nginx/sites-enabled/default" do
+    action :delete
+  end
+
   service "nginx" do
     supports :status => true, :restart => true
     action [ :start, :enable ]
@@ -262,11 +268,6 @@ elsif node[:swift][:frontend]=='apache'
     action [ :start, :enable ]
   end
 
-
-  file "/etc/nginx/sites-enabled/default" do
-    action :delete
-    notifies :restart, resources(:service => "nginx")
-  end
 
   template "/etc/nginx/sites-enabled/swift-proxy.conf" do
     source "nginx-swift-proxy.conf.erb"


### PR DESCRIPTION
nginx failed to start because of bad default config file.

link to default config file should be removed anyway, we make our own.

 chef/cookbooks/swift/recipes/proxy.rb |   11 ++++++-----
 1 file changed, 6 insertions(+), 5 deletions(-)

Crowbar-Pull-ID: 0dd9603cfd774d680d622e9d52c7f970631807fc

Crowbar-Release: pebbles
