### PR TITLE
Dell Rally: US3022 SWIFT: enhancement: allow deployers to choose to enabled auth_delay_deny [1/1]

### DIFF
--- a/chef/cookbooks/swift/attributes/default.rb
+++ b/chef/cookbooks/swift/attributes/default.rb
@@ -1,5 +1,6 @@
 #
 # Copyright 2011, Dell
+# Copyright 2013, Dell
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,6 +15,7 @@
 # limitations under the License.
 #
 # Author: andi abes
+# Author: Judd Maltin
 #
 ### The cluster hash is shared among all nodes in a swift cluster.
 ### can be generated using od -t x8 -N 8 -A n </dev/random
@@ -81,6 +83,7 @@ default[:swift][:keystone_instance] = "proposal"
 default[:swift][:reseller_prefix] = "AUTH_"
 default[:swift][:keystone_service_user] = "swift"
 default[:swift][:keystone_service_password] = "swift"
+default[:swift][:keystone_delay_auth_decision] = true
 
 default[:swift][:install_slog_from_dev] = false
 

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -118,6 +118,7 @@ case proxy_config[:auth_method]
      keystone_service_tenant = keystone["keystone"]["service"]["tenant"] rescue nil
      keystone_service_user = node["swift"]["keystone_service_user"]
      keystone_service_password = node["swift"]["keystone_service_password"]
+     keystone_delay_auth_decision = node["swift"]["keystone_delay_auth_decision"] rescue nil
 
      Chef::Log.info("Keystone server found at #{keystone_address}")
      proxy_config[:keystone_admin_token]  = keystone_token
@@ -129,6 +130,8 @@ case proxy_config[:auth_method]
      proxy_config[:keystone_service_user] = keystone_service_user
      proxy_config[:keystone_service_password] = keystone_service_password
      proxy_config[:reseller_prefix] = node[:swift][:reseller_prefix]
+     proxy_config[:keystone_delay_auth_decision] = keystone_delay_auth_decision
+
 
      keystone_register "register swift user" do
        host keystone_address

--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 # Author: andi abes
+# Author: Judd Maltin
 #
 
 #
@@ -59,7 +60,7 @@ use = egg:swift#proxy
 <% if @account_management == "true" %>allow_account_management = true<% end %>
 <% if @keystone %>account_autocreate = true<% end %>
 log_name = proxy-server
-log_facility = LOG_LOCAL1
+log_facility = LOG_LOCAL5
 log_level = DEBUG
 access_log_name = proxy-server
 access_log_facility = LOG_LOCAL1
@@ -109,6 +110,11 @@ auth_token = <%= @keystone_admin_token %>
 admin_token = <%= @keystone_admin_token %>
 
 [filter:auth_token]
+# Delaying the auth decision is required to support token-less
+# usage for anonymous referrers ('.r:*').
+# delay_auth_decision = true
+delay_auth_decision = <%= @keystone_delay_auth_decision %>
+
 paste.filter_factory = keystone.middleware.auth_token:filter_factory
 auth_host = <%= @keystone_vip %>
 auth_port = <%= @keystone_admin_port %>

--- a/chef/data_bags/crowbar/bc-template-swift.json
+++ b/chef/data_bags/crowbar/bc-template-swift.json
@@ -88,6 +88,7 @@
       "auth_method": "keystone",
       "keystone_instance": "proposal",
       "keystone_service_user": "swift",
+      "keystone_delay_auth_decision": false,
       "reseller_prefix" : "AUTH_",
       "user": "swift",
       "group": "swift",

--- a/chef/data_bags/crowbar/bc-template-swift.schema
+++ b/chef/data_bags/crowbar/bc-template-swift.schema
@@ -113,6 +113,7 @@
             "keystone_instance": { "type": "str", "required": false },            
             "keystone_service_user": { "type": "str", "required": true },
             "keystone_service_password": { "type": "str" },
+            "keystone_delay_auth_decision": { "type": "bool", "required": false },
             "reseller_prefix": { "type": "str", "required": false },            
             "user": { "type": "str", "required": true },
             "group": { "type": "str", "required": true },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -99,6 +99,7 @@ locale_additions:
           keystone_instance: Keystone instance
           keystone_service_user: Keystone Service User
           keystone_service_password: Keystone Service Password
+          keystone_delay_auth_decision: Allow Public Containers (performance penalty)
           install_slog: Install sLogging support
           slog_account: sLogging swift account
           slog_user: sLogging swift user

--- a/crowbar_framework/app/views/barclamp/swift/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/swift/_edit_attributes.html.haml
@@ -13,6 +13,9 @@
     %p
       %label{ :for => :keystone_service_password }= t('.keystone_service_password')
       %input#keystone_service_password{:type => "text", :name => "keystone_service_password", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["keystone_service_password"], :onchange => "update_value('keystone_service_password','keystone_service_password', 'string')"}
+    %p
+      %label{ :for => :keystone_delay_auth_decision }= t('.keystone_delay_auth_decision')
+      = select_tag :keystone_delay_auth_decision, options_for_select([['false', 'false'], ['true', 'true']], @proposal.raw_data['attributes'][@proposal.barclamp]["keystone_delay_auth_decision"].to_s), :onchange => "update_value('keystone_delay_auth_decision', 'keystone_delay_auth_decision', 'boolean')"
 
     -# %p
       -# %label{ :for => :use_slog }= t('.install_slog')


### PR DESCRIPTION
ally: US3022 SWIFT: enhancement: allow deployers to choose to enabled auth_delay_deny

 chef/cookbooks/swift/attributes/default.rb         |    3 +++
 chef/cookbooks/swift/recipes/proxy.rb              |    3 +++
 .../swift/templates/default/proxy-server.conf.erb  |    8 +++++++-
 chef/data_bags/crowbar/bc-template-swift.json      |    1 +
 chef/data_bags/crowbar/bc-template-swift.schema    |    1 +
 crowbar.yml                                        |    1 +
 .../barclamp/swift/_edit_attributes.html.haml      |    3 +++
 7 files changed, 19 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 5486e10424f0340e8d124f962039fc575265e9f4

Crowbar-Release: pebbles
