### PR TITLE
Use new render_instance_selector helper and do not show service-related bits in UI

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -97,8 +97,6 @@ locale_additions:
           debug: Debug
           auth_method: Authentication method
           keystone_instance: Keystone instance
-          keystone_service_user: Keystone Service User
-          keystone_service_password: Keystone Service Password
           keystone_delay_auth_decision: Allow Public Containers (performance penalty)
           install_slog: Install sLogging support
           slog_account: sLogging swift account

--- a/crowbar_framework/app/views/barclamp/swift/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/swift/_edit_attributes.html.haml
@@ -6,12 +6,6 @@
   %div.container
     = render_instance_selector("keystone", :keystone_instance, t('.keystone_instance'), "keystone_instance", @proposal)
     %p
-      %label{ :for => :keystone_service_user }= t('.keystone_service_user')
-      %input#keystone_service_user{:type => "text", :name => "keystone_service_user", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["keystone_service_user"], :onchange => "update_value('keystone_service_user','keystone_service_user', 'string')"}
-    %p
-      %label{ :for => :keystone_service_password }= t('.keystone_service_password')
-      %input#keystone_service_password{:type => "text", :name => "keystone_service_password", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["keystone_service_password"], :onchange => "update_value('keystone_service_password','keystone_service_password', 'string')"}
-    %p
       %label{ :for => :keystone_delay_auth_decision }= t('.keystone_delay_auth_decision')
       = select_tag :keystone_delay_auth_decision, options_for_select([['false', 'false'], ['true', 'true']], @proposal.raw_data['attributes'][@proposal.barclamp]["keystone_delay_auth_decision"].to_s), :onchange => "update_value('keystone_delay_auth_decision', 'keystone_delay_auth_decision', 'boolean')"
 


### PR DESCRIPTION
For service-related bits: end users don't need to change this (and we already generate a random password); it can still be changed in the json if really needed.
