### PR TITLE
Use :install and not :upgrade for installing packages

### DIFF
--- a/chef/cookbooks/memcached/recipes/default.rb
+++ b/chef/cookbooks/memcached/recipes/default.rb
@@ -25,7 +25,7 @@ when "suse"
 when "debian", "ubuntu"
   %w{libmemcache-dev memcached}.each do |pkg|
     package pkg do
-      action :upgrade
+      action :install
     end
   end
 end

--- a/chef/cookbooks/swift/recipes/storage.rb
+++ b/chef/cookbooks/swift/recipes/storage.rb
@@ -34,7 +34,7 @@ unless node[:swift][:use_gitrepo]
     %w{swift-container swift-object swift-account}.each do |pkg|
       pkg = "openstack-#{pkg}" if node[:platform] == "suse"
       package pkg do
-        action :upgrade
+        action :install
       end
     end
   end


### PR DESCRIPTION
As agreed during a community call, we want to use :install to allow
upgrades being controlled instead of automatically installed.
