### PR TITLE
The keystone auth_token middleware has been move to keystoneclient [1/4]

### DIFF
--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -115,7 +115,7 @@ admin_token = <%= @keystone_admin_token %>
 # delay_auth_decision = true
 delay_auth_decision = <%= @keystone_delay_auth_decision %>
 
-paste.filter_factory = keystone.middleware.auth_token:filter_factory
+paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
 auth_host = <%= @keystone_vip %>
 auth_port = <%= @keystone_admin_port %>
 auth_protocol = http


### PR DESCRIPTION
Using keystone.middleware.auth_token causes problems on nodes that don't have
the server side of keystone installed.

 chef/cookbooks/swift/templates/default/proxy-server.conf.erb | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 197808408153b82a03525bc760b96ecadfb330c3

Crowbar-Release: pebbles
