### PR TITLE
Add non-configurable attribute for http/https use in keystone [4/7]

### DIFF
--- a/chef/cookbooks/swift/recipes/dispersion.rb
+++ b/chef/cookbooks/swift/recipes/dispersion.rb
@@ -23,6 +23,7 @@ else
 end
 
 keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+keystone_protocol = keystone["keystone"]["api"]["protocol"]
 keystone_token = keystone["keystone"]["service"]["token"] rescue nil
 keystone_service_port = keystone["keystone"]["api"]["service_port"] rescue nil
 keystone_admin_port = keystone["keystone"]["api"]["admin_port"] rescue nil
@@ -30,7 +31,7 @@ keystone_admin_port = keystone["keystone"]["api"]["admin_port"] rescue nil
 service_tenant = node[:swift][:dispersion][:service_tenant]
 service_user = node[:swift][:dispersion][:service_user]
 service_password = node[:swift][:dispersion][:service_password]
-keystone_auth_url = "http://#{keystone_address}:#{keystone_admin_port}/v2.0"
+keystone_auth_url = "#{keystone_protocol}://#{keystone_address}:#{keystone_admin_port}/v2.0"
 
 keystone_register "swift dispersion wakeup keystone" do
   host keystone_address

--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -121,6 +121,7 @@ case proxy_config[:auth_method]
      end
      
      keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+     keystone_protocol = keystone["keystone"]["api"]["protocol"]
      keystone_token = keystone["keystone"]["service"]["token"] rescue nil
      keystone_service_port = keystone["keystone"]["api"]["service_port"] rescue nil
      keystone_admin_port = keystone["keystone"]["api"]["admin_port"] rescue nil
@@ -130,6 +131,7 @@ case proxy_config[:auth_method]
      keystone_delay_auth_decision = node["swift"]["keystone_delay_auth_decision"] rescue nil
 
      Chef::Log.info("Keystone server found at #{keystone_address}")
+     proxy_config[:keystone_protocol] = keystone_protocol
      proxy_config[:keystone_admin_token]  = keystone_token
      proxy_config[:keystone_vip] = keystone_address
      proxy_config[:keystone_admin_port] = keystone_admin_port
@@ -143,6 +145,7 @@ case proxy_config[:auth_method]
 
 
      keystone_register "register swift user" do
+       protocol keystone_protocol
        host keystone_address
        port keystone_admin_port
        token keystone_token
@@ -153,6 +156,7 @@ case proxy_config[:auth_method]
      end
 
      keystone_register "give swift user access" do
+       protocol keystone_protocol
        host keystone_address
        port keystone_admin_port
        token keystone_token
@@ -163,6 +167,7 @@ case proxy_config[:auth_method]
      end
 
      keystone_register "register swift service" do
+       protocol keystone_protocol
        host keystone_address
        token keystone_token
        port keystone_admin_port
@@ -173,6 +178,7 @@ case proxy_config[:auth_method]
      end                                                 
 
      keystone_register "register swift-proxy endpoint" do
+         protocol keystone_protocol
          host keystone_address
          token keystone_token
          port keystone_admin_port

--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -105,7 +105,7 @@ service_port = <%= @keystone_service_port %>
 service_host = <%= @keystone_vip %>
 auth_port = <%= @keystone_admin_port %>
 auth_host = <%= @keystone_vip %>
-auth_protocol = http
+auth_protocol = <%= @keystone_protocol %>
 auth_token = <%= @keystone_admin_token %>
 admin_token = <%= @keystone_admin_token %>
 
@@ -118,8 +118,8 @@ delay_auth_decision = <%= @keystone_delay_auth_decision %>
 paste.filter_factory = keystone.middleware.auth_token:filter_factory
 auth_host = <%= @keystone_vip %>
 auth_port = <%= @keystone_admin_port %>
-auth_protocol = http
-auth_uri = http://<%= @keystone_vip %>:<%= @keystone_service_port %>/
+auth_protocol = <%= @keystone_protocol %>
+auth_uri = <%= @keystone_protocol %>://<%= @keystone_vip %>:<%= @keystone_service_port %>/
 admin_tenant_name = <%= @keystone_service_tenant %>
 admin_user = <%= @keystone_service_user %>
 admin_password = <%= @keystone_service_password %>


### PR DESCRIPTION
In short: this doesn't change the current behavior, and is only a
preparatory commit for future SSL support in keystone.

This is set to http right now; this will enable other barclamps to use
this attribute without breaking them, and then we can make this
configurable.

Crowbar-Pull-ID: 4572857ca9291f4fab46772cbbe8ff0a06969160

Crowbar-Release: pebbles
