### PR TITLE
make key file private

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -208,6 +208,7 @@ execute "create auth cert" do
   user node[:swift][:user]
   command <<-EOH
   /usr/bin/openssl req -new -x509 -days 365 -nodes -out cert.crt -keyout cert.key -batch &>/dev/null 0</dev/null
+  chmod 640 cert.key
   EOH
   not_if  {::File.exist?("/etc/swift/cert.crt") } 
 end


### PR DESCRIPTION
private key files should not be world-readable which would be bad for security
