### PR TITLE
Fix to not use AHCI drives for Swift/Cloudera storage when RAID BC is in effect [3/3]

### DIFF
--- a/chef/cookbooks/swift/recipes/disks.rb
+++ b/chef/cookbooks/swift/recipes/disks.rb
@@ -31,10 +31,13 @@ def get_uuid(disk)
 end
 
 Chef::Log.info("locating disks using #{node[:swift][:disk_enum_expr]} test: #{node[:swift][:disk_test_expr]}")
+
 to_use_disks = []
 all_disks = eval(node[:swift][:disk_enum_expr])
 all_disks.each { |k,v|
   b = binding()
+  #skip if the disk is ahci and we have raid.
+  next if v.is_ahci and node[:crowbar_wall].has_key?('raid')
   to_use_disks << k if eval(node[:swift][:disk_test_expr]) && ::File.exists?("/dev/#{k}")
 }
 


### PR DESCRIPTION
Fix to not use AHCI drives for Swift/Cloudera storage when RAID BC is in effect

 chef/cookbooks/swift/recipes/disks.rb |    3 +++
 1 file changed, 3 insertions(+)

Crowbar-Pull-ID: a2e3e9e6f50d18a819a17c7936ab0b6145094f14

Crowbar-Release: mesa-1.6
