### PR TITLE
Create ResellerAdmin role in keystone

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -143,6 +143,16 @@ case proxy_config[:auth_method]
      proxy_config[:reseller_prefix] = node[:swift][:reseller_prefix]
      proxy_config[:keystone_delay_auth_decision] = keystone_delay_auth_decision
 
+     # ResellerAdmin is used by swift (see reseller_admin_role option)
+     role = "ResellerAdmin"
+     keystone_register "add #{role} role for swift" do
+       protocol keystone_protocol
+       host keystone_address
+       port keystone_admin_port
+       token keystone_token
+       role_name role
+       action :add_role
+     end
 
      keystone_register "register swift user" do
        protocol keystone_protocol


### PR DESCRIPTION
Quoting the swift doc:

 Users with the Keystone role defined in reseller_admin_role
 (ResellerAdmin by default) can operate on any account. The auth system
 sets the request environ reseller_request to True if a request is
 coming from an user with this role. This can be used by other
 middlewares.

As this role is not used by any other OpenStack component, it makes
sense to create that role here, and not in the keystone cookbook.
