### PR TITLE
DE1344 - UtilitiesTempest and Swift Dispersion report opens a new window, removed target='_blank' attribute from hrefs [2/2]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -34,7 +34,7 @@ crowbar:
 
 nav:
   utils:
-    swift: "/swift/dashboard/"
+    swift: '"/swift/dashboard/"'
 
 locale_additions:
   en:


### PR DESCRIPTION
 crowbar.yml |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 219ae547387bbc7312532b0d60194aa6154970a4

Crowbar-Release: mesa-1.6
