### PR TITLE
[NavMenu] Don't open in new tab/window

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -34,7 +34,7 @@ crowbar:
 
 nav:
   utils:
-    swift: '"/swift/dashboard/", { :link => { :target => "_blank" } }'
+    swift: '"/swift/dashboard/"'
 
 locale_additions:
   en:


### PR DESCRIPTION
All other barclamps open in the same tab/window, so we should be
consistent here. General rule is that if it's in the same domain, don't
open a new tab/window.
