### PR TITLE
single-zone, single-server deployment off-by-one error fixed [1/1]

### DIFF
--- a/chef/cookbooks/swift/libraries/rack_awareness.rb
+++ b/chef/cookbooks/swift/libraries/rack_awareness.rb
@@ -59,7 +59,7 @@ class Rack_awareness
     def switch_to_zone()
         #set switch to zone by round-robin
         zone_count=@node[:swift][:zones]
-        zone_list=*(0..zone_count-1)
+        zone_list=zone_count.times.to_a
         switch_list=@switch_list
         switch_list.keys.each do |sw_name|
              switch_list["#{sw_name}"]["zones"]=[] if not switch_list["#{sw_name}"].has_key?("zones")
@@ -69,7 +69,7 @@ class Rack_awareness
             #some switches may have same zone with each other
             switch_list.keys.sort.each do |sw_name|
                 zone=zone_list.shift
-                zone_list=*(0..zone_count-1) if zone_list.size == 0
+                zone_list=zone_count.times.to_a if zone_list.size == 0
                 switch_list["#{sw_name}"]["zones"] << zone
             end
         else


### PR DESCRIPTION
 chef/cookbooks/swift/libraries/rack_awareness.rb |    4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)

Crowbar-Pull-ID: 4089a7c7d71dd2511da473a3079e3e1ec3e84e1a

Crowbar-Release: mesa-1.6
