### PR TITLE
Use default 'log_name' in /etc/swift/proxy-server.conf

### DIFF
--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -30,7 +30,6 @@ user = <%= @user %>
 group = <%= @group %>
 log_facility = LOG_LOCAL0
 log_level = <%= @debug? "DEBUG": "INFO" %>
-log_name = swift-p
 log_requests = true
 setup_console_handler = true
 


### PR DESCRIPTION
Swift's internal logging framework is buggy, i.e when setting something
different than the default ('swift'), you'll get a warning when the
daemon is started 'No handlers could be found for logger "swift-p"'.
This should also fix log messages ending up on the tty's, e.g.:

admin:~ #
Message from syslogd@d52-54-00-26-22-39 at Jul 11 13:16:56 ...
 <131>swift-p ERROR with Account server
 192.168.125.11:6002/c113d48aacc445cf9694699f46adf8f5 re: Trying to get
 account info for /AUTH_6e48217cbf744995a23b2f0c448557af: Connection
 refused (txn: txf795266a95d048a9b89ab103febbc007) (client_ip:
 192.168.126.2)
