### PR TITLE
Stop installing python-keystone package

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -117,11 +117,7 @@ case proxy_config[:auth_method]
        keystone = node
      end
 
-     unless node[:swift][:use_gitrepo]
-       package "python-keystone" do
-         action :install
-       end 
-     else
+     if node[:swift][:use_gitrepo]
        if node[:swift][:use_virtualenv]
          pfs_and_install_deps "keystone" do
            cookbook "keystone"


### PR DESCRIPTION
This is not needed since commit 2d62ccb, when we moved to using
keystoneclient.middleware.auth_token.
