### PR TITLE
DE1389 remove cname_lookup from swift UI [1/1]

### DIFF
--- a/crowbar_framework/app/views/barclamp/swift/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/swift/_edit_attributes.html.haml
@@ -119,18 +119,6 @@
           %label{ :for => :storage_domain }= t('.middlewares.storage_domain')
           %input#storage_domain{:type => "text", :name => "storage_domain", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["middlewares"]["domain_remap"]["storage_domain"], :onchange => "update_value('middlewares/domain_remap/storage_domain', 'storage_domain', 'string')"}
       %p
-        %label{ :for => :cname_lookup }= t('.middlewares.cname_lookup')
-      %div.container
-        %p
-          %label{ :for => :enable_cname_lookup }= t('.middlewares.enabled')
-          = select_tag :enable_cname_lookup, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["middlewares"]["cname_lookup"]["enabled"].to_s), :onchange => "update_value('middlewares/cname_lookup/enabled', 'enable_cname_lookup', 'boolean')"
-        %p
-          %label{ :for => :lookup_depth }= t('.middlewares.lookup_depth')
-          %input#lookup_depth{:type => "text", :name => "lookup_depth", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["middlewares"]["cname_lookup"]["lookup_depth"], :onchange => "update_value('middlewares/cname_lookup/lookup_depth', 'lookup_depth', 'integer')"}
-        %p
-          %label{ :for => :storage_domain_cname_lookup }= t('.middlewares.storage_domain')
-          %input#storage_domain_cname_lookup{:type => "text", :name => "storage_domain_cname_lookup", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["middlewares"]["cname_lookup"]["storage_domain"], :onchange => "update_value('middlewares/cname_lookup/storage_domain', 'storage_domain_cname_lookup', 'string')"}
-      %p
         %label{ :for => :ratelimit }= t('.middlewares.ratelimit')
       %div.container
         %p


### PR DESCRIPTION
Removing cname_lookup

Middleware that translate an unknown domain in the host header to something that ends with the configured storage_domain by looking up
the given domain's name CNAME record in DNS.
This feature kills nova_dashboard.

 .../barclamp/swift/_edit_attributes.html.haml      |   12 ------------
 1 file changed, 12 deletions(-)

Crowbar-Pull-ID: 0cc5c5131ca61499d585efbe5e4736aeeb20a7c0

Crowbar-Release: mesa-1.6
