### PR TITLE
Reenable running nova_dashboard and swift on same node [1/3]

### DIFF
--- a/chef/cookbooks/memcached/definitions/memcached_instance.rb
+++ b/chef/cookbooks/memcached/definitions/memcached_instance.rb
@@ -20,6 +20,8 @@
 define :memcached_instance do
   include_recipe "memcached"
 
+  opts = params
+
   case node[:platform]
   when "suse"
     service "memcached" do
@@ -32,7 +34,7 @@ define :memcached_instance do
       options({
         :memory => node[:memcached][:memory],
         :port => node[:memcached][:port],
-        :user => node[:memcached][:user]}.merge(params)
+        :user => node[:memcached][:user]}.merge(opts)
       )
     end
   end


### PR DESCRIPTION
This pull request makes the following changes:
- Adds execute permission back to the nova smoktest script so that it is executed as part of the smoketest
- Changes the instance of memcached that nova_dashboard spawns to use port 11212 instead of the default port 11211.  This fixes a regression where nova_dashboard and swift can no longer be installed on the same node, which in turn reenables running the nova_dashboard and swift smoketests on the same setup.
- To make the above changes work, a fix to the OpsCode memcached_instance recipe was merged in so that it would not ignore the port specification.
  
  .../memcached/definitions/memcached_instance.rb    |    4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)

Crowbar-Pull-ID: 0a2d343d5a3fdb6cb5f0ee49feb6270348a6afe7

Crowbar-Release: pebbles
