### PR TITLE
Disable container report by default

### DIFF
--- a/chef/cookbooks/swift/templates/default/disperse.conf.erb
+++ b/chef/cookbooks/swift/templates/default/disperse.conf.erb
@@ -6,4 +6,11 @@ dispersion_coverage = <%= node["swift"]["dispersion"]["dispersion_coverage"] %>
 retries = <%= node["swift"]["dispersion"]["retries"] %>
 concurrency = <%= node["swift"]["dispersion"]["concurrency"] %>
 auth_version = 2.0
-dump_json = true
+# dump_json = no
+# object_report = yes
+container_report = no
+
+# endpoint_type = publicURL
+# keystone_api_insecure = no
+#
+# swift_dir = /etc/swift

--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -233,7 +233,7 @@ class SwiftService < ServiceObject
     @logger.info("starting dispersion-report on node #{node}, report run uuid #{report_run['uuid']}")
 
     pid = fork do
-      command_line = "sudo -u #{swift_user} swift-dispersion-report 2>/dev/null"
+      command_line = "sudo -u #{swift_user} EVENTLET_NO_GREENDNS=yes swift-dispersion-report -j 2>/dev/null"
       Process.waitpid run_remote_chef_client(node, command_line, report_run["results.json"])
 
       report_run["ended"] = Time.now.utc.to_i


### PR DESCRIPTION
Replication of containers is very CPU intensive, and creating
2560 for "reporting" is a bit too much overhead by default.
