### PR TITLE
Only rotate /var/log/(warn,messages,localmessages) 9 time

### DIFF
--- a/chef/cookbooks/swift/recipes/default.rb
+++ b/chef/cookbooks/swift/recipes/default.rb
@@ -59,3 +59,12 @@ template "/etc/swift/swift.conf" do
  })
 end
 
+if node[:platform] == "suse"
+  # Only rotate log-files 9 times (instead of 99)
+  template "/etc/logrotate.d/syslog" do
+    owner "root"
+    group "root"
+    mode "0644"
+    source "logrotate_d.syslog.conf"
+  end
+end

--- a/chef/cookbooks/swift/templates/default/logrotate_d.syslog.conf
+++ b/chef/cookbooks/swift/templates/default/logrotate_d.syslog.conf
@@ -1,0 +1,59 @@
+#
+# Please note, that changing of log file permissions in this
+# file is not sufficient if syslog-ng is used as log daemon.
+#
+# It is required to specify the permissions in the syslog-ng
+# configuration file /etc/syslog-ng/syslog-ng.conf as well.
+#
+
+# the firewall,acpid,NetworkManager log files
+# are used by syslog-ng and rsyslog only, the
+# other by all syslog daemons.
+/var/log/warn /var/log/messages /var/log/allmessages /var/log/localmessages /var/log/firewall /var/log/acpid /var/log/NetworkManager {
+    compress
+    dateext
+    maxage 365
+    rotate 9
+    missingok
+    notifempty
+    size +4096k
+    create 640 root root
+    sharedscripts
+    postrotate
+        /etc/init.d/syslog reload > /dev/null
+    endscript
+}
+
+# used by all syslog daemons
+/var/log/mail /var/log/mail.info /var/log/mail.warn /var/log/mail.err {
+    compress
+    dateext
+    maxage 365
+    rotate 9
+    missingok
+    notifempty
+    size +4096k
+    create 640 root root
+    sharedscripts
+    postrotate
+        /etc/init.d/syslog reload > /dev/null
+    endscript
+}
+
+# used by all syslog daemons
+/var/log/news/news.crit /var/log/news/news.err /var/log/news/news.notice {
+    compress
+    dateext
+    maxage 365
+    rotate 9
+    missingok
+    notifempty
+    size +4096k
+    su news news
+    create 640 news news
+    sharedscripts
+    postrotate
+        /etc/init.d/syslog reload > /dev/null
+    endscript
+}
+


### PR DESCRIPTION
The SLES default is 99. Previously and together with "size +4096k", this could easily fill up ~400MB on the admin node.

It's currently SUSE-specific by the way.
