### PR TITLE
addresses #129 - fix bad regex match on some swift-ring-compute output [1/1]

### DIFF
--- a/chef/cookbooks/swift/providers/ringfile.rb
+++ b/chef/cookbooks/swift/providers/ringfile.rb
@@ -116,7 +116,7 @@ def scan_ring_desc(input)
       
       when :dev_info  #              0     1 192.168.124.131  6002      sdb1 100.00          0 -100.00
       Chef::Log.debug "reading dev info:" + line
-      line =~ /^\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+\.\d+\.\d+\.\d+)\s+(\d+)\s+(\S+)\s+([0-9.]+)\s+(\d+)\s+([-0-9.]+)\s*$/
+      line =~ /^\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+\.\d+\.\d+\.\d+)\s+(\d+)\s+(\S+)\s+([0-9.]+)\s+(\d+)\s*([-0-9.]+)\s*$/
       if $~.nil? 
         raise "failed to parse: #{line}"
       else


### PR DESCRIPTION
 chef/cookbooks/swift/providers/ringfile.rb |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: d530e4ef671e1b177d06b1d16de6958a628e4c5e

Crowbar-Release: pebbles
