### PR TITLE
Adding the user/group attributes for Swift Dispersion Report [1/1]

### DIFF
--- a/chef/data_bags/crowbar/bc-template-swift.json
+++ b/chef/data_bags/crowbar/bc-template-swift.json
@@ -89,6 +89,8 @@
       "keystone_instance": "proposal",
       "keystone_service_user": "swift",
       "keystone_delay_auth_decision": false,
+      "user":"swift",
+      "group":"swift",
       "reseller_prefix" : "AUTH_",
       "debug": false,
       "use_slog" : false,


### PR DESCRIPTION
The user/group attributes are required for swift dispersion report to run from the crowbar UI. The smoketests may not be using it.

 chef/data_bags/crowbar/bc-template-swift.json |    2 ++
 1 file changed, 2 insertions(+)

Crowbar-Pull-ID: feaf6b57156999fe5fd154a92ff5d33153249fcb

Crowbar-Release: roxy
