### PR TITLE
Set log_facility for keystonauth middleware (cherry-pick from pebbles)

### DIFF
--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -95,6 +95,8 @@ log_level = <%= @debug? "DEBUG": "INFO" %>
 use = egg:swift#keystoneauth
 operator_roles = Member,admin
 reseller_prefix=<%= @reseller_prefix %>
+log_facility = LOG_LOCAL0
+log_level = <%= @debug? "DEBUG": "INFO" %>
 
 # NOTE(chmou): s3token middleware is not updated yet to use only
 # username and password.


### PR DESCRIPTION
Otherwise, unconfigured keystoneclient logging triggers annoying
syslog messages:

$ swift --insecure list

Message from syslogd@d52-54-00-26-22-3a at Sep 13 13:47:02 ...
 <131>proxy-server STDOUT: No handlers could be found for logger
 "keystoneclient.common.cms" (txn: txe68451518fc146169ef57b4ee4d83fa5)
