### PR TITLE
Increase http read timeout from 500 to 3600

### DIFF
--- a/bin/crowbar_swift
+++ b/bin/crowbar_swift
@@ -17,5 +17,6 @@
 
 require File.join(File.expand_path(File.dirname(__FILE__)), "barclamp_lib")
 @barclamp = "swift"
+@timeout = 3600
 
 main


### PR DESCRIPTION
Prevent the crowbar client raising a timeout exception
as swift deployment time exceeds that timeout.
