### PR TITLE
propose swift services according to intended roles

### DIFF
--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -88,7 +88,8 @@ class SwiftService < ServiceObject
     }
 
     if nodes.size > 0
-      storage_nodes     = nodes.select { |n| n if n.intended_role == "storage" } || nodes
+      storage_nodes     = nodes.select { |n| n if n.intended_role == "storage" }
+      storage_nodes     = nodes if storage_nodes.empty?
       controller        = nodes.detect { |n| n if n.intended_role == "controller"} || nodes.shift
       base["deployment"]["swift"]["elements"] = {
         "swift-dispersion"      => [ controller[:fqdn] ],


### PR DESCRIPTION
Use the intended role set for the nodes to propose swift deployment.
(Requires changes in barclamp-crowbar: crowbar/barclamp-crowbar#796)
