### PR TITLE
python-keystoneclient needed for keystone authentication

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -108,9 +108,7 @@ end
 
 case proxy_config[:auth_method]
    when "swauth"
-     package "python-swauth" do
-       action :install
-     end 
+     package "python-swauth"
      proxy_config[:admin_key] =node[:swift][:cluster_admin_pw]
      proxy_config[:account_management] = node[:swift][:account_management]
 
@@ -138,6 +136,8 @@ case proxy_config[:auth_method]
            cnode keystone
          end
        end
+     else
+       package "python-keystoneclient"
      end
      
      keystone_host = keystone[:fqdn]


### PR DESCRIPTION
SUSE bug: bnc#850511 - swift-proxy-server deployment fails on node that doesn't run keystone

Backport of roxy-based https://github.com/crowbar/barclamp-swift/pull/156
