### PR TITLE
set modes of directories only for git mode

### DIFF
--- a/chef/cookbooks/swift/recipes/default.rb
+++ b/chef/cookbooks/swift/recipes/default.rb
@@ -29,6 +29,8 @@ unless node[:swift][:use_gitrepo]
     package "swift"
   end
 
+else
+
   ["/etc/swift", "/var/lock/swift"].each do |d|
     directory d do
       owner node[:swift][:user]
@@ -42,8 +44,6 @@ unless node[:swift][:use_gitrepo]
     group node[:swift][:group]
     mode "0700"
   end
-
-else
 
   pfs_and_install_deps @cookbook_name do
     path swift_path


### PR DESCRIPTION
1. mode for /var/cache/swift needs to be 700 (https://bugzilla.novell.com/show_bug.cgi?id=858194)
2. modes are set by openstack-swift package now, hence no need to set them here if installed from packages
