### PR TITLE
make generate-certs true by default

### DIFF
--- a/chef/data_bags/crowbar/bc-template-swift.json
+++ b/chef/data_bags/crowbar/bc-template-swift.json
@@ -61,7 +61,7 @@
       "ssl": {
           "certfile": "/etc/swift/cert.crt",
           "keyfile": "/etc/swift/cert.key",
-          "generate_certs": false,
+          "generate_certs": true,
           "insecure": false
       },
       "replication_interval": 60,


### PR DESCRIPTION
Might be seen as insecure, but it is the same behavior like with previous versions without having option for entering ssl certificate....
