### PR TITLE
Fix syntax error

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -115,7 +115,7 @@ end
 
 # enable ceilometer middleware if ceilometer is configured
 node[:swift][:middlewares]["ceilometer"] = {
-  "enabled"   => node.roles.include? "ceilometer-swift-proxy-middleware"
+  "enabled" => (node.roles.include? "ceilometer-swift-proxy-middleware")
 }
 
 case proxy_config[:auth_method]


### PR DESCRIPTION
Apparently, the previous code is not valid.

[Thu, 30 Jan 2014 13:25:37 +0100] FATAL: SyntaxError: compile error
/var/chef/cache/cookbooks/swift/recipes/proxy.rb:117: syntax error, unexpected tSTRING_BEG, expecting '}'
...bled" => node.roles.include? "ceilometer-swift-proxy-middlew...
                              ^
/var/chef/cache/cookbooks/swift/recipes/proxy.rb:117: syntax error, unexpected '}', expecting $end
