### PR TITLE
Fix 002_add_ceilometer_middleware.rb

### DIFF
--- a/chef/data_bags/crowbar/migrate/swift/002_add_ceilometer_middleware.rb
+++ b/chef/data_bags/crowbar/migrate/swift/002_add_ceilometer_middleware.rb
@@ -1,6 +1,6 @@
 def upgrade ta, td, a, d
   a["middlewares"]["ceilometer"] = {}
-  a["middlewares"]["ceilometer"]["enabled"] = ta["middlewares"]["ceilometer"]["enabled"]
+  a["middlewares"]["ceilometer"]["enabled"] = ta["middlewares"]["ceilometer"]["enabled"] rescue false
   return a, d
 end
 


### PR DESCRIPTION
It got broken because the middleware got removed later on, so accessing
ta["middlewares"]["ceilometer"]["enabled"] raised an exception.
