### PR TITLE
Move Swift lock files to /var/run

### DIFF
--- a/chef/cookbooks/swift/recipes/default.rb
+++ b/chef/cookbooks/swift/recipes/default.rb
@@ -4,9 +4,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,7 @@ unless node[:swift][:use_gitrepo]
 
 else
 
-  ["/etc/swift", "/var/lock/swift"].each do |d|
+  ["/etc/swift", "/var/run/swift"].each do |d|
     directory d do
       owner node[:swift][:user]
       group node[:swift][:group]
@@ -60,7 +60,7 @@ end
 template "/etc/swift/swift.conf" do
   owner node[:swift][:user]
   group node[:swift][:group]
-  source "swift.conf.erb"  
+  source "swift.conf.erb"
  variables( {
        :swift_cluster_hash => node[:swift][:cluster_hash]
  })

--- a/chef/cookbooks/swift/templates/default/rsyncd.conf.erb
+++ b/chef/cookbooks/swift/templates/default/rsyncd.conf.erb
@@ -25,22 +25,22 @@ address =  <%= @storage_net_ip %>
 max connections = 64
 path = /srv/node/
 read only = false
-lock file = /var/lock/swift/account.lock
+lock file = /var/run/swift/account.lock
 
 [container]
 max connections = 64
 path = /srv/node/
 read only = false
-lock file = /var/lock/swift/container.lock
+lock file = /var/run/swift/container.lock
 
 [object]
 max connections = 64
 path = /srv/node/
 read only = false
-lock file = /var/lock/swift/object.lock
+lock file = /var/run/swift/object.lock
 
 [ring]
 max connections = 64
 path = /etc/swift
 read only = false
-lock file = /var/lock/swift/ring.lock
+lock file = /var/run/swift/ring.lock


### PR DESCRIPTION
As /var/lock is deprecated and blacklisted on openSUSE/SLE12
