### PR TITLE
remove openstack- prefix from user/group for SUSE

### DIFF
--- a/chef/cookbooks/swift/attributes/default.rb
+++ b/chef/cookbooks/swift/attributes/default.rb
@@ -32,15 +32,8 @@ default[:swift][:min_part_hours]= 1
 default[:swift][:partitions]= 18
 
 ### the uid/gid to be used for swift processes
-case node[:platform]
-when "suse"
-  default[:swift][:user]= "openstack-swift"
-  default[:swift][:group]= "openstack-swift"
-else
-  default[:swift][:user]= "swift"
-  default[:swift][:group]= "swift"
-end
-
+default[:swift][:user]= "swift"
+default[:swift][:group]= "swift"
 
 default[:swift][:config] = {}
 default[:swift][:config][:environment] = "default"


### PR DESCRIPTION
Make this more uniform accross distributions.
