### PR TITLE
Feature: Add option to use only local drives

### DIFF
--- a/chef/cookbooks/swift/attributes/default.rb
+++ b/chef/cookbooks/swift/attributes/default.rb
@@ -85,7 +85,8 @@ default[:swift][:keystone_service_user] = "swift"
 default[:swift][:keystone_service_password] = "swift"
 default[:swift][:keystone_delay_auth_decision] = false
 
+default[:swift][:local_drives] = true
+
 default[:swift][:install_slog_from_dev] = false
 
 default[:keystone][:frontend] = 'uwsgi'
-

--- a/chef/cookbooks/swift/recipes/disks.rb
+++ b/chef/cookbooks/swift/recipes/disks.rb
@@ -59,6 +59,14 @@ to_use_disks.each do |d|
   disk[:device_disk_partition] = k + partition_suffix
   disk[:uuid] = get_uuid(target_dev_part)
 
+  # Check physical disk label to ensure that disk is local.
+  if node[:swift][:local_disks]
+    unless ::Kernel.system ("/lib/udev/scsi_id -g -u -d #{target_dev} > /dev/null")
+     Chef::Log.info("Skipping non-local drive #{target_dev}")
+     next
+    end
+  end
+
   # Test to see if there is a partition table on the disk.
   # If not, create a shiny new GPT partition table for the disk.
   if ::Kernel.system("parted -s -m #{target_dev} print 1 |grep -q '^Error:'")

--- a/chef/data_bags/crowbar/bc-template-swift.json
+++ b/chef/data_bags/crowbar/bc-template-swift.json
@@ -91,6 +91,7 @@
       "keystone_delay_auth_decision": false,
       "reseller_prefix" : "AUTH_",
       "debug": false,
+      "local_disks": true,
       "use_slog" : false,
       "slog_account": "system_stats",
       "slog_user": "swift_sys",

--- a/chef/data_bags/crowbar/bc-template-swift.schema
+++ b/chef/data_bags/crowbar/bc-template-swift.schema
@@ -118,6 +118,7 @@
             "user": { "type": "str", "required": false },
             "group": { "type": "str", "required": false },
             "debug": { "type": "bool", "required": false},
+            "local_disks": { "type": "bool", "required": false },
             "frontend": { "type": "str", "required": true },
             "use_slog": { "type": "bool", "required": false},
             "slog_account": { "type": "str", "required": false},

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -96,6 +96,7 @@ locale_additions:
           user: User
           group: Group
           debug: Debug
+          local_disks: Use only local disks
           auth_method: Authentication method
           keystone_instance: Keystone instance
           keystone_delay_auth_decision: Allow Public Containers (performance penalty)

--- a/crowbar_framework/app/views/barclamp/swift/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/swift/_edit_attributes.html.haml
@@ -50,6 +50,10 @@
     %p
       %label{ :for => :debug }= t('.debug')
       = select_tag :debug, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["debug"].to_s), :onchange => "update_value('debug', 'debug', 'boolean')"
+
+    %p
+      %label{ :for => :local_disks }= t('.local_disks')
+      = select_tag :local_disks, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["local_disks"].to_s), :onchange => "update_value('local_disks', 'local_disks', 'boolean')"
     %label.section-header{ :for => :middlewares }= t('.middlewares.label')
     %div.section{ :id => 'middlewares' }
 


### PR DESCRIPTION
Features:
- Expose in UI option to select only local drives for deployment
- Speedup Swift deployment for complex deployments
- Add another protection layer for network block storages mounted outside Crowbar

Test case:
- Mount blank iSCSI drive
- Deploy Swift
- Make sure that iSCSI drive untouched
