### PR TITLE
Do not force people to use the swift-dispersion node

### DIFF
--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -285,7 +285,6 @@ class SwiftService < PacemakerServiceObject
   end
 
   def validate_proposal_after_save proposal
-    validate_one_for_role proposal, "swift-dispersion"
     validate_one_for_role proposal, "swift-proxy"
     validate_one_for_role proposal, "swift-ring-compute"
     validate_at_least_n_for_role proposal, "swift-storage", 1


### PR DESCRIPTION
This role is optional. And people won't be able to assign more than one
node, thanks to the constraint (that is used for validation too).
