### PR TITLE
Increasing swift smoketest timeout.

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -26,6 +26,9 @@ barclamp:
   member:
     - openstack
 
+smoketest:
+  timeout: 600
+
 crowbar:
   layout: 1
   order: 80


### PR DESCRIPTION
Increasing swift smoketest timeout up to 600 seconds.
