### PR TITLE
Replaced barclamp controller initialzer with before filter

### DIFF
--- a/crowbar_framework/app/controllers/swift_controller.rb
+++ b/crowbar_framework/app/controllers/swift_controller.rb
@@ -19,10 +19,6 @@ class SwiftController < BarclampController
   helper_method :available_nodes
   helper_method :ready_nodes
 
-  def initialize
-    @service_object = SwiftService.new logger
-  end
-
   def dashboard
     @reports = reports_list
     render :template => "barclamp/#{@bc_name}/dashboard"
@@ -122,5 +118,9 @@ class SwiftController < BarclampController
 
   def raise_not_found
     raise ActionController::RoutingError.new("Not found")
+  end
+
+  def initialize_service
+    @service_object = SwiftService.new logger
   end
 end


### PR DESCRIPTION
I transfered the service initialize into a before filter. It's a quite dirty practice to overwrite the controller initializer and the way it is done now will result in problems while upgrading to rails 3 or 4.
**This depends on https://github.com/crowbar/barclamp-crowbar/pull/1036**
