### PR TITLE
Added rsyslog rule to filter out swift-proxy messages into separare log file

### DIFF
--- a/chef/cookbooks/swift/recipes/default.rb
+++ b/chef/cookbooks/swift/recipes/default.rb
@@ -66,3 +66,13 @@ template "/etc/swift/swift.conf" do
  })
 end
 
+rsyslog_version = `rsyslogd -v | head -1 | sed -e "s/^rsyslogd \(.*\), .*$/\1/"`
+# log swift components into separate log files
+template "/etc/rsyslog.d/11-swift.conf" do
+  source     "11-swift.conf.erb"
+  mode       "0755"
+  group       node[:swift][:group]
+  owner       node[:swift][:user]
+  variables(:rsyslog_version => rsyslog_version)
+  only_if     { node[:platform] == "suse" } # other distros might not have /var/log/swift
+end

--- a/chef/cookbooks/swift/templates/default/11-swift.conf.erb
+++ b/chef/cookbooks/swift/templates/default/11-swift.conf.erb
@@ -1,0 +1,38 @@
+# Log swift components into separate log files (and nowhere else)
+
+# proxy-server logs
+if      ($programname == 'swift-p') \
+then    -/var/log/swift/proxy-server.log
+<% if @rsyslog_version < "7" %>
+&       ~
+<% else %>
+&       stop
+<% end %>
+
+# container-server logs
+if      ($programname == 'swift-c') \
+then    -/var/log/swift/container-server.log
+<% if @rsyslog_version < "7" %>
+&       ~
+<% else %>
+&       stop
+<% end %>
+
+# object server logs
+if      ($programname == 'swift-o') \
+then    -/var/log/swift/object-server.log
+<% if @rsyslog_version < "7" %>
+&       ~
+<% else %>
+&       stop
+<% end %>
+
+# account server logs
+if      ($programname == 'swift-a') \
+then    -/var/log/swift/account-server.log
+<% if @rsyslog_version < "7" %>
+&       ~
+<% else %>
+&       stop
+<% end %>
+


### PR DESCRIPTION
See https://bugzilla.novell.com/show_bug.cgi?id=879931

Some notes:
- we have defined 30-swift.conf.erb that should be deployed by slog recipe
- I have a feeling that slog part is obsolete/not working anyway
- if that is true, I'd propose to also remove slog related parts
- BTW, using that 30-swift.conf.erb instead of new 11-swift-proxy.conf.erb does not seem to work

Creation of the log directory would be done in package spec file.
