### PR TITLE
Fix permission & ownership of /etc/rsyslog.d/11-swift.conf

### DIFF
--- a/chef/cookbooks/swift/recipes/default.rb
+++ b/chef/cookbooks/swift/recipes/default.rb
@@ -70,9 +70,7 @@ rsyslog_version = `rsyslogd -v | head -1 | sed -e "s/^rsyslogd \(.*\), .*$/\1/"`
 # log swift components into separate log files
 template "/etc/rsyslog.d/11-swift.conf" do
   source     "11-swift.conf.erb"
-  mode       "0755"
-  group       node[:swift][:group]
-  owner       node[:swift][:user]
+  mode       "0644"
   variables(:rsyslog_version => rsyslog_version)
   only_if     { node[:platform] == "suse" } # other distros might not have /var/log/swift
 end


### PR DESCRIPTION
It doesn't need the +x bit, and should be owned by root.
