### PR TITLE
Update config template files to Icehouse

### DIFF
--- a/chef/cookbooks/swift/templates/default/container-server-conf.erb
+++ b/chef/cookbooks/swift/templates/default/container-server-conf.erb
@@ -18,7 +18,9 @@ workers = 2
 # max_clients = 1024
 #
 # This is a comma separated list of hosts allowed in the X-Container-Sync-To
-# field for containers.
+# field for containers. This is the old-style of using container sync. It is
+# strongly recommended to use the new style of a separate
+# container-sync-realms.conf -- see container-sync-realms.conf-sample
 # allowed_sync_hosts = 127.0.0.1
 #
 # You can specify default log routing here if you want:
@@ -152,7 +154,9 @@ interval = <%= node[:swift][:replication_interval] %>
 # log_address = /dev/log
 #
 # If you need to use an HTTP Proxy, set it here; defaults to no proxy.
-# sync_proxy = http://127.0.0.1:8888
+# You can also set this to a comma separated list of HTTP Proxies and they will
+# be randomly used (simple load balancing).
+# sync_proxy = http://10.1.1.1:8888,http://10.1.1.2:8888
 #
 # Will sync each container at most once per interval
 # interval = 300

--- a/chef/cookbooks/swift/templates/default/dispersion.conf.erb
+++ b/chef/cookbooks/swift/templates/default/dispersion.conf.erb
@@ -13,6 +13,8 @@ keystone_api_insecure = <%= @keystone_settings['insecure'] ? "yes" : "no" %>
 dispersion_coverage = <%= node["swift"]["dispersion"]["dispersion_coverage"] %>
 retries = <%= node["swift"]["dispersion"]["retries"] %>
 concurrency = <%= node["swift"]["dispersion"]["concurrency"] %>
+# container_populate = yes
+# object_populate = yes
 container_report = no
 # object_report = yes
 # dump_json = no

--- a/chef/cookbooks/swift/templates/default/object-server-conf.erb
+++ b/chef/cookbooks/swift/templates/default/object-server-conf.erb
@@ -9,6 +9,7 @@ user = <%= node[:swift][:user] %>
 # mount_check = true
 # disable_fallocate = false
 # expiring_objects_container_divisor = 86400
+# expiring_objects_account_name = expiring_objects
 #
 # Use an integer to override the number of pre-forked processes that will
 # accept connections.
@@ -45,6 +46,17 @@ log_level = <%= @debug? "DEBUG": "INFO" %>
 # You can set fallocate_reserve to the number of bytes you'd like fallocate to
 # reserve, whether there is space for the given file size or not.
 # fallocate_reserve = 0
+#
+# Time to wait while attempting to connect to another backend node.
+# conn_timeout = 0.5
+# Time to wait while sending each chunk of data to another backend node.
+# node_timeout = 3
+# Time to wait while receiving each chunk of data from a client or another
+# backend node.
+# client_timeout = 60
+#
+# network_chunk_size = 65536
+# disk_chunk_size = 65536
 
 [pipeline:main]
 pipeline = healthcheck recon object-server
@@ -58,10 +70,6 @@ use = egg:swift#object
 log_requests = true
 # set log_address = /dev/log
 #
-# node_timeout = 3
-# conn_timeout = 0.5
-# network_chunk_size = 65536
-# disk_chunk_size = 65536
 # max_upload_time = 86400
 # slow = 0
 #
@@ -82,6 +90,10 @@ log_requests = true
 #
 # auto_create_account_prefix = .
 #
+# A value of 0 means "don't use thread pools". A reasonable starting point is
+# 4.
+# threads_per_disk = 0
+#
 # Configure parameter for creating specific server
 # To handle all verbs, including replication verbs, do not specify
 # "replication_server" (this is the default). To only handle replication,
@@ -89,8 +101,30 @@ log_requests = true
 # verbs, set to "False". Unless you have a separate replication network, you
 # should not specify any value for "replication_server".
 # replication_server = false
-# A value of 0 means "don't use thread pools". A reasonable starting point is 4.
-# threads_per_disk = 0
+#
+# Set to restrict the number of concurrent incoming REPLICATION requests
+# Set to 0 for unlimited
+# Note that REPLICATION is currently an ssync only item
+# replication_concurrency = 4
+#
+# Restricts incoming REPLICATION requests to one per device,
+# replication_currency above allowing. This can help control I/O to each
+# device, but you may wish to set this to False to allow multiple REPLICATION
+# requests (up to the above replication_concurrency setting) per device.
+# replication_one_per_device = True
+#
+# Number of seconds to wait for an existing replication device lock before
+# giving up.
+# replication_lock_timeout = 15
+#
+# These next two settings control when the REPLICATION subrequest handler will
+# abort an incoming REPLICATION attempt. An abort will occur if there are at
+# least threshold number of failures and the value of failures / successes
+# exceeds the ratio. The defaults of 100 and 1.0 means that at least 100
+# failures have to occur and there have to be more failures than successes for
+# an abort to occur.
+# replication_failure_threshold = 100
+# replication_failure_ratio = 1.0
 
 [filter:healthcheck]
 use = egg:swift#healthcheck
@@ -116,16 +150,24 @@ run_pause = <%= node[:swift][:replication_interval] %>
 # concurrency = 1
 # stats_interval = 300
 #
+# The sync method to use; default is rsync but you can use ssync to try the
+# EXPERIMENTAL all-swift-code-no-rsync-callouts method. Once ssync is verified
+# as having performance comparable to, or better than, rsync, we plan to
+# deprecate rsync so we can move on with more features for replication.
+# sync_method = rsync
+#
 # max duration of a partition rsync
 # rsync_timeout = 900
 #
-# bandwith limit for rsync in kB/s. 0 means unlimited
+# bandwidth limit for rsync in kB/s. 0 means unlimited
 # rsync_bwlimit = 0
 #
 # passed to rsync for io op timeout
 # rsync_io_timeout = 30
 #
-# max duration of an http request
+# node_timeout = <whatever's in the DEFAULT section or 10>
+# max duration of an http request; this is for REPLICATE finalization calls and
+# so should be longer than node_timeout
 # http_timeout = 60
 #
 # attempts to kill all workers if nothing replicates for lockup_timeout seconds
@@ -140,6 +182,25 @@ run_pause = <%= node[:swift][:replication_interval] %>
 # limits how long rsync error log lines are
 # 0 means to log the entire line
 # rsync_error_log_line_length = 0
+#
+# handoffs_first and handoff_delete are options for a special case
+# such as disk full in the cluster. These two options SHOULD NOT BE
+# CHANGED, except for such an extreme situations. (e.g. disks filled up
+# or are about to fill up. Anyway, DO NOT let your drives fill up)
+# handoffs_first is the flag to replicate handoffs prior to canonical
+# partitions. It allows to force syncing and deleting handoffs quickly.
+# If set to a True value(e.g. "True" or "1"), partitions
+# that are not supposed to be on the node will be replicated first.
+# handoffs_first = False
+#
+# handoff_delete is the number of replicas which are ensured in swift.
+# If the number less than the number of replicas is set, object-replicator
+# could delete local handoffs even if all replicas are not ensured in the
+# cluster. Object-replicator would remove local handoff partition directories
+# after syncing partition when the number of successful responses is greater
+# than or equal to this number. By default(auto), handoff partitions will be
+# removed  when it has successfully replicated to all the canonical nodes.
+# handoff_delete = auto
 
 [object-updater]
 # You can override the default log routing for this app here (don't use set!):
@@ -150,9 +211,7 @@ run_pause = <%= node[:swift][:replication_interval] %>
 #
 # interval = 300
 # concurrency = 1
-# node_timeout = 10
-# conn_timeout = 0.5
-#
+# node_timeout = <whatever's in the DEFAULT section or 10>
 # slowdown will sleep that amount between objects
 # slowdown = 0.01
 #

--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -5,7 +5,20 @@ bind_port = <%= @bind_port %>
 # backlog = 4096
 # swift_dir = /etc/swift
 user = <%= @user %>
+
+# Enables exposing configuration settings via HTTP GET /info.
+# expose_info = true
+
+# Key to use for admin calls that are HMAC signed.  Default is empty,
+# which will disable admin calls to /info.
+# admin_key = secret_admin_key
 #
+# Allows the ability to withhold sections from showing up in the public
+# calls to /info.  The following would cause the sections 'container_quotas'
+# and 'tempurl' to not be listed.  Default is empty, allowing all registered
+# fetures to be listed via HTTP GET /info.
+# disallowed_sections = container_quotas, tempurl
+
 # Use an integer to override the number of pre-forked processes that will
 # accept connections.  Should default to the number of effective cpu
 # cores in the system.  It's worth noting that individual workers will
@@ -23,6 +36,7 @@ key_file = <%= @ssl_keyfile %>
 <% end -%>
 #
 # expiring_objects_container_divisor = 86400
+# expiring_objects_account_name = expiring_objects
 #
 # You can specify default log routing here if you want:
 log_name = swift-p
@@ -83,7 +97,7 @@ log_level = <%= @debug? "DEBUG": "INFO" %>
   crossdomain = middlewares.delete("crossdomain")
 %>
 [pipeline:main]
-pipeline = catch_errors healthcheck proxy-logging cache <%= bulk %> slo <%= ratelimit %> <%= cname_lookup %> <%= domain_remap %> <%= tempurl %> <%= formpost %> <%= crossdomain %> <%= auth %> <%= staticweb %> container-quotas account-quotas proxy-logging <%= middlewares.join(' ') %> <%= ceilometer %> proxy-server
+pipeline = catch_errors gatekeeper healthcheck proxy-logging cache container_sync <%= bulk %> <%= tempurl %> slo dlo <%= ratelimit %> <%= cname_lookup %> <%= domain_remap %> <%= formpost %> <%= crossdomain %> <%= auth %> <%= staticweb %> container-quotas account-quotas proxy-logging <%= middlewares.join(' ') %> <%= ceilometer %> proxy-server
 
 [app:proxy-server]
 use = egg:swift#proxy
@@ -105,8 +119,24 @@ log_requests = true
 # recheck_container_existence = 60
 # object_chunk_size = 8192
 # client_chunk_size = 8192
+#
+# How long the proxy server will wait on responses from the a/c/o servers.
 # node_timeout = 10
+#
+# How long the proxy server will wait for an initial response and to read a
+# chunk of data from the object servers while serving GET / HEAD requests.
+# Timeouts from these requests can be recovered from so setting this to
+# something lower than node_timeout would provide quicker error recovery
+# while allowing for a longer timeout for non-recoverable requests (PUTs).
+# Defaults to node_timeout, should be overriden if node_timeout is set to a
+# high number to prevent client timeouts from firing before the proxy server
+# has a chance to retry.
+# recoverable_node_timeout = node_timeout
+#
 # conn_timeout = 0.5
+#
+# How long to wait for requests to finish after a quorum has been established.
+# post_quorum_timeout = 0.5
 #
 # How long without an error before a node's error count is reset. This will
 # also be how long before a node is reenabled after suppression is triggered.
@@ -148,14 +178,6 @@ account_autocreate = <%= @auth_method == "keystone" ? "true" : "false" %>
 # Depth of the proxy put queue.
 # put_queue_depth = 10
 #
-# Start rate-limiting object segment serving after the Nth segment of a
-# segmented object.
-# rate_limit_after_segment = 10
-#
-# Once segment rate-limiting kicks in for an object, limit segments served
-# to N per second.
-# rate_limit_segments_per_sec = 1
-#
 # Storage nodes can be chosen at random (shuffle), by using timing
 # measurements (timing), or by using an explicit match (affinity).
 # Using timing measurements may allow for lower overall latency, while
@@ -168,11 +190,6 @@ account_autocreate = <%= @auth_method == "keystone" ? "true" : "false" %>
 # If the "timing" sorting_method is used, the timings will only be valid for
 # the number of seconds configured by timing_expiry.
 # timing_expiry = 300
-#
-# If set to false will treat objects with X-Static-Large-Object header set
-# as a regular object on GETs, i.e. will return that object's contents. Should
-# be set to false if slo is not used in pipeline.
-# allow_static_large_object = true
 #
 # The maximum time (seconds) that a large object connection is allowed to last.
 # max_large_object_get_time = 86400
@@ -214,7 +231,8 @@ account_autocreate = <%= @auth_method == "keystone" ? "true" : "false" %>
 # These are the headers whose values will only be shown to swift_owners. The
 # exact definition of a swift_owner is up to the auth system in use, but
 # usually indicates administrative responsibilities.
-# swift_owner_headers = x-container-read, x-container-write, x-container-sync-key, x-container-sync-to, x-account-meta-temp-url-key, x-account-meta-temp-url-key-2
+# swift_owner_headers = x-container-read, x-container-write, x-container-sync-key, x-container-sync-to, x-account-meta-temp-url-key, x-account-meta-temp-url-key-2, x-account-access-control
+
 
 [filter:tempauth]
 use = egg:swift#tempauth
@@ -291,6 +309,7 @@ insecure = <%= @keystone_settings['insecure'] %>
 <% end -%>
 delay_auth_decision = <%= @keystone_delay_auth_decision %>
 # cache = swift.cache
+# include_service_catalog = False
 signing_dir = /var/cache/swift/keystone-signing
 
 [filter:keystoneauth]
@@ -339,6 +358,9 @@ memcache_servers = <%= @memcached_ips %>
 # set to 2 and reload.
 # In the future, the ability to use pickle serialization will be removed.
 # memcache_serialization_support = 2
+#
+# Sets the maximum number of connections to each memcached server per worker
+# memcache_max_connections = 2
 
 [filter:ratelimit]
 use = egg:swift#ratelimit
@@ -419,13 +441,17 @@ use = egg:swift#cname_lookup
 # set log_headers = false
 # set log_address = /dev/log
 #
+# Specify the storage_domain that match your cloud, multiple domains
+# can be specified separated by a comma
 storage_domain = <%= @storage_domain %>
+#
 lookup_depth = <%= @lookup_depth %>
 
 # Note: Put staticweb just after your auth filter(s) in the pipeline
 [filter:staticweb]
 use = egg:swift#staticweb
 
+# Note: Put tempurl before dlo, slo and your auth filter(s) in the pipeline
 [filter:tempurl]
 use = egg:swift#tempurl
 # The methods allowed with Temp URLs.
@@ -488,6 +514,11 @@ use = egg:swift#proxy_logging
 # access_log_statsd_metric_prefix =
 # access_log_headers = false
 #
+# If access_log_headers is True and access_log_headers_only is set only
+# these headers are logged. Multiple headers can be defined as comma separated
+# list like this: access_log_headers_only = Host, X-Object-Meta-Mtime
+# access_log_headers_only =
+#
 # By default, the X-Auth-Token is logged. To obscure the value,
 # set reveal_sensitive_prefix to the number of characters to log.
 # For example, if set to 12, only the first 12 characters of the
@@ -517,7 +548,19 @@ max_containers_per_extraction = <%= @max_containers_per_extraction %>
 max_failed_extractions = <%= @max_failed_extractions %>
 max_deletes_per_request = <%= @max_deletes_per_request %>
 max_failed_deletes = <%= @max_failed_deletes %>
+
+# In order to keep a connection active during a potentially long bulk request,
+# Swift may return whitespace prepended to the actual response body. This
+# whitespace will be yielded no more than every yield_frequency seconds.
 yield_frequency = <%= @yield_frequency %>
+
+# Note: The following parameter is used during a bulk delete of objects and
+# their container. This would frequently fail because it is very likely
+# that all replicated objects have not been deleted by the time the middleware got a
+# successful response. It can be configured the number of retries. And the
+# number of seconds to wait between each retry will be 1.5**retry
+
+# delete_container_retry_count = 0
 
 # Note: Put after auth in the pipeline.
 [filter:container-quotas]
@@ -529,9 +572,53 @@ use = egg:swift#slo
 # max_manifest_segments = 1000
 # max_manifest_size = 2097152
 # min_segment_size = 1048576
+# Start rate-limiting SLO segment serving after the Nth segment of a
+# segmented object.
+# rate_limit_after_segment = 10
+#
+# Once segment rate-limiting kicks in for an object, limit segments served
+# to N per second. 0 means no rate-limiting.
+# rate_limit_segments_per_sec = 0
+#
+# Time limit on GET requests (seconds)
+# max_get_time = 86400
+
+# Note: Put before both ratelimit and auth in the pipeline, but after
+# gatekeeper, catch_errors, and proxy_logging (the first instance).
+# If you don't put it in the pipeline, it will be inserted for you.
+[filter:dlo]
+use = egg:swift#dlo
+# Start rate-limiting DLO segment serving after the Nth segment of a
+# segmented object.
+# rate_limit_after_segment = 10
+#
+# Once segment rate-limiting kicks in for an object, limit segments served
+# to N per second. 0 means no rate-limiting.
+# rate_limit_segments_per_sec = 1
+#
+# Time limit on GET requests (seconds)
+# max_get_time = 86400
 
 [filter:account-quotas]
 use = egg:swift#account_quotas
+
+[filter:gatekeeper]
+use = egg:swift#gatekeeper
+# You can override the default log routing for this filter here:
+# set log_name = gatekeeper
+# set log_facility = LOG_LOCAL0
+# set log_level = INFO
+# set log_headers = false
+# set log_address = /dev/log
+
+[filter:container_sync]
+use = egg:swift#container_sync
+# Set this to false if you want to disallow any full url values to be set for
+# any new X-Container-Sync-To headers. This will keep any new full urls from
+# coming in, but won't change any existing values already in the cluster.
+# Updating those will have to be done manually, as knowing what the true realm
+# endpoint should be cannot always be guessed.
+# allow_full_urls = true
 
 ### External filters
 

--- a/chef/cookbooks/swift/templates/default/swift.conf.erb
+++ b/chef/cookbooks/swift/templates/default/swift.conf.erb
@@ -48,11 +48,12 @@ swift_hash_path_suffix = <%= @swift_cluster_hash  %>
 
 #max_meta_overall_size = 4096
 
-
 # max_header_size is the max number of bytes in the utf8 encoding of each
-# header. Using 8192 as default becasue eventlet use 8192 as max size of
-# header line and the longest header passed from Keystone(PKI token) uses
-# 8192 as default too.
+# header. Using 8192 as default because eventlet use 8192 as max size of
+# header line. This value may need to be increased when using identity
+# v3 API tokens including more than 7 catalog entries.
+# See also include_service_catalog in proxy-server.conf-sample
+# (documented in overview_auth.rst)
 
 #max_header_size = 8192
 


### PR DESCRIPTION
The most important change is in the middleware pipeline for the proxy:
- gatekeeper, container_sync and dlo are added:
  - gatekeeper got added to filter headers.
  - container_sync is a new middleware related to configuration of
    container sync. We could add a config file for container_sync
    (container-sync-realms.conf) but we didn't have any config for
    that before, so we should be fine.
  - dlo simply got split (like slo before)
- tempurl is moved before slo and dlo, as suggested by the doc.
