### PR TITLE
fix 'No handlers could be found for logger "swift-proxy"' warning

### DIFF
--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -39,7 +39,7 @@ key_file = <%= @ssl_keyfile %>
 # expiring_objects_account_name = expiring_objects
 #
 # You can specify default log routing here if you want:
-log_name = swift-p
+log_name = proxy-server
 # log_facility = LOG_LOCAL0
 log_level = <%= @debug? "DEBUG": "INFO" %>
 # log_headers = false


### PR DESCRIPTION
Don't ask me why this works; it just does.  I found the idea here:

  https://ask.openstack.org/en/question/27166/no-handlers-could-be-found-for-logger-swift-proxy/?answer=27172#post-id-27172

but nothing in the manual explains why log_name should matter for
anything other than what appears in the logs:

  http://docs.openstack.org/icehouse/config-reference/content/proxy-server-configuration.html
