### PR TITLE
Restart rsyslog after creating /etc/rsyslog.d/11-swift.conf

### DIFF
--- a/chef/cookbooks/swift/recipes/default.rb
+++ b/chef/cookbooks/swift/recipes/default.rb
@@ -66,7 +66,7 @@ template "/etc/swift/swift.conf" do
  })
 end
 
-rsyslog_version = `rsyslogd -v | head -1 | sed -e "s/^rsyslogd \(.*\), .*$/\1/"`
+rsyslog_version = `rsyslogd -v | head -1 | sed -e "s/^rsyslogd \\(.*\\), .*$/\\1/"`
 # log swift components into separate log files
 template "/etc/rsyslog.d/11-swift.conf" do
   source     "11-swift.conf.erb"


### PR DESCRIPTION
Otherwise, the file is simply not used.
