### PR TITLE
Enable rsync service on boot

### DIFF
--- a/chef/cookbooks/swift/recipes/rsync.rb
+++ b/chef/cookbooks/swift/recipes/rsync.rb
@@ -36,7 +36,7 @@ end
 
 unless %w(redhat centos).include?(node.platform)
   service "rsync" do
-    action :start
+    action [:enable, :start]
     service_name "rsyncd" if %w(suse).include?(node.platform)
   end
 else


### PR DESCRIPTION
We want it to start on boot, so that it's there even when chef-client
failed to start it for some reason.
