### PR TITLE
set the log level to match ceilometer's one (solves bnc#879095)

### DIFF
--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -644,6 +644,7 @@ super_admin_key = <%= @admin_key %>
 
 [filter:ceilometer]
 use = egg:ceilometer#swift
+set log_level = WARN
 
 <% if !@cross_domain_policy.empty? %>
 [filter:crossdomain]


### PR DESCRIPTION
It's https://github.com/crowbar/barclamp-swift/pull/266 for Stoney
