### PR TITLE
Use region from keystone settings

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy.rb
+++ b/chef/cookbooks/swift/recipes/proxy.rb
@@ -244,7 +244,7 @@ case proxy_config[:auth_method]
          token keystone_settings['admin_token']
          port keystone_settings['admin_port']
          endpoint_service "swift"
-         endpoint_region "RegionOne"
+         endpoint_region keystone_settings['endpoint_region']
          endpoint_publicURL "#{swift_protocol}://#{public_host}:#{node[:swift][:ports][:proxy]}/v1/#{node[:swift][:reseller_prefix]}$(tenant_id)s"
          endpoint_adminURL "#{swift_protocol}://#{admin_host}:#{node[:swift][:ports][:proxy]}/v1/"
          endpoint_internalURL "#{swift_protocol}://#{admin_host}:#{node[:swift][:ports][:proxy]}/v1/#{node[:swift][:reseller_prefix]}$(tenant_id)s"


### PR DESCRIPTION
The keystone barclamp got the possibility to set a custom region
name. This name must be used by other barclamps as well.

related to: https://bugzilla.novell.com/show_bug.cgi?id=896481

(cherry picked from commit 27ad1be4a4ee8d0256055122848546041dbd1fc4)
