### PR TITLE
Only deal with pacemaker resources on the founder node (bnc#918104)

### DIFF
--- a/chef/cookbooks/swift/recipes/proxy_ha.rb
+++ b/chef/cookbooks/swift/recipes/proxy_ha.rb
@@ -38,14 +38,14 @@ pacemaker_primitive service_name do
   op    node[:swift][:ha]["proxy"][:op]
   action :create
   # Do not even try to start the daemon if we don't have the ring yet
-  only_if { ::File.exists? "/etc/swift/object.ring.gz" }
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) && ::File.exists?("/etc/swift/object.ring.gz") }
 end
 
 pacemaker_clone "cl-#{service_name}" do
   rsc service_name
   action [ :create, :start ]
   # Do not even try to start the daemon if we don't have the ring yet
-  only_if { ::File.exists? "/etc/swift/object.ring.gz" }
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) && ::File.exists?("/etc/swift/object.ring.gz") }
 end
 
 crowbar_pacemaker_sync_mark "create-swift_ha_resources" do


### PR DESCRIPTION
There's no real point in having all nodes try to update all pacemaker
resources all the time, and it actually can lead to issues due to races
when two non-founder nodes try to update the resource at the same time.

It's worth mentioning that for service LWRP, we actually want to do a
:start on each run to ensure that the service is restarted in case it
crashed. For pacemaker resources, the :start doesn't need to be done all
the time: as a crash of the service is caught by pacemaker already. So
if the founder goes missing, this won't hurt us.

http://bugzilla.suse.com/show_bug.cgi?id=918104