### PR TITLE
[WIP] Temporary workaround breakage

### DIFF
--- a/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
+++ b/chef/cookbooks/swift/templates/default/proxy-server.conf.erb
@@ -734,7 +734,7 @@ set default_swift_cluster = local#<%= @swift_protocol %>://<%= @admin_host %>:<%
 super_admin_key = <%= @admin_key %>
 
 [filter:ceilometer]
-use = egg:ceilometer#swift
+paste.filter_factory = ceilometer.objectstore.swift_middleware:filter_factory
 set log_level = WARN
 
 <% if !@cross_domain_policy.empty? %>


### PR DESCRIPTION
I'm seeing this crash when starting swift-proxy with the ceilometer middleware:

```
Traceback (most recent call last):
  File "/usr/bin/swift-proxy-server", line 23, in <module>
    sys.exit(run_wsgi(conf_file, 'proxy-server', default_port=8080, **options))
  File "/usr/lib64/python2.6/site-packages/swift/common/wsgi.py", line 432, in run_wsgi
    loadapp(conf_path, global_conf=global_conf)
  File "/usr/lib64/python2.6/site-packages/swift/common/wsgi.py", line 352, in loadapp
    ctx = loadcontext(loadwsgi.APP, conf_file, global_conf=global_conf)
  File "/usr/lib64/python2.6/site-packages/swift/common/wsgi.py", line 336, in loadcontext
    global_conf=global_conf)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 296, in loadcontext
    global_conf=global_conf)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 320, in _loadconfig
    return loader.get_context(object_type, name, global_conf)
  File "/usr/lib64/python2.6/site-packages/swift/common/wsgi.py", line 61, in get_context
    object_type, name=name, global_conf=global_conf)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 450, in get_context
    global_additions=global_additions)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 562, in _pipeline_app_context
    for name in pipeline[:-1]]
  File "/usr/lib64/python2.6/site-packages/swift/common/wsgi.py", line 61, in get_context
    object_type, name=name, global_conf=global_conf)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 454, in get_context
    section)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 476, in _context_from_use
    object_type, name=use, global_conf=global_conf)
  File "/usr/lib64/python2.6/site-packages/swift/common/wsgi.py", line 61, in get_context
    object_type, name=name, global_conf=global_conf)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 406, in get_context
    global_conf=global_conf)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 296, in loadcontext
    global_conf=global_conf)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 328, in _loadegg
    return loader.get_context(object_type, name, global_conf)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 620, in get_context
    object_type, name=name)
  File "/usr/lib64/python2.6/site-packages/paste/deploy/loadwsgi.py", line 640, in find_egg_entry_point
    pkg_resources.require(self.spec)
  File "/usr/lib64/python2.6/site-packages/pkg_resources.py", line 696, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/lib64/python2.6/site-packages/pkg_resources.py", line 594, in resolve
    raise DistributionNotFound(req)
pkg_resources.DistributionNotFound: testtools
```

I think in the end, it's a packaging problem. But this is an easy workaround.