### PR TITLE
Replace ProposalObject with Chef::DataBag

### DIFF
--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -169,7 +169,7 @@ class SwiftService < PacemakerServiceObject
   end
 
   def get_ready_proposals
-    Proposal.where(barclamp: @bc_name).all.select {|p| p.status == 'ready'}.compact
+    Proposal.where(barclamp: @bc_name).select {|p| p.status == 'ready'}.compact
   end
 
   def _get_or_create_db
@@ -305,7 +305,7 @@ class SwiftService < PacemakerServiceObject
 
   def validate_proposal_after_save proposal
     # first, check for conflict with ceph
-    Proposal.where(barclamp: "ceph").all.each {|p|
+    Proposal.where(barclamp: "ceph").each {|p|
       next unless (p.status == "ready") || (p.status == "pending")
       elements = (p.status == "ready") ? p.role.elements : p.elements
       if elements.keys.include?("ceph-radosgw") && !elements['ceph-radosgw'].empty?

--- a/crowbar_framework/app/models/swift_service.rb
+++ b/crowbar_framework/app/models/swift_service.rb
@@ -173,7 +173,7 @@ class SwiftService < PacemakerServiceObject
   end
 
   def _get_or_create_db
-    db = Chef::DataBag.load "crowbar/swift"
+    db = Chef::DataBag.load("crowbar/swift") rescue nil
     if db.nil?
       begin
         lock = acquire_lock @bc_name


### PR DESCRIPTION
The code uses ProposalObject api just to store the dispersion results in
a data bag. Use Chef::DataBag directly.

Refs https://github.com/crowbar/barclamp-crowbar/pull/1269